### PR TITLE
Correct IMAGE_INSTALL variable so not to fail when apt-get installs packages

### DIFF
--- a/conf/machine/include/dh-stm32mp1-common.inc
+++ b/conf/machine/include/dh-stm32mp1-common.inc
@@ -70,7 +70,7 @@ INITRAMFS_FSTYPES ?= "cpio.xz"
 EXTRA_IMAGEDEPENDS += "virtual/bootloader"
 WKS_FILE = "sdimage-stm32mp1.wks"
 IMAGE_BOOT_FILES ?= "${KERNEL_IMAGETYPE}"
-IMAGE_INSTALL_append = " kernel-devicetree kernel-image-fitimage virtual/bootloader "
+IMAGE_INSTALL_append = " kernel-devicetree kernel-image-fitimage ${PREFERRED_PROVIDER_virtual/bootloader} "
 do_image_wic[depends] += "mtools-native:do_populate_sysroot dosfstools-native:do_populate_sysroot virtual/bootloader:do_deploy"
 
 # Add any optional config files that might be present e.g. in other layers


### PR DESCRIPTION
This commit is to solve the following problem (how to reproduce):

1- In file build/conf/local.conf: change `PACKAGE_CLASSES ?= "package_rpm"` to `PACKAGE_CLASSES ?= "package_deb"`.
2- Build with the command `bitbake core-image-full-cmdline`

You will get the following error:

```
ERROR: core-image-full-cmdline-1.0-r0 do_rootfs: Unable to install packages. Command '/path/to/project/build/tmp/work/dh_stm32mp1_dhcom_pdk2-poky-linux-gnueabi/core-image-full-cmdline/1.0-r0/recipe-sysroot-native/usr/bin/apt-get  install --force-yes --allow-unauthenticated --no-remove apt cgdb dnsmasq dpkg hostapd iw kernel-devicetree kernel-image-fitimage libgpiod libgpiod-dev libgpiod-tools lsof packagegroup-base packagegroup-core-boot packagegroup-core-buildessential packagegroup-core-full-cmdline packagegroup-core-ssh-openssh psplash python3 run-postinsts sair-scripts tcpdump virtual/bootloader wpa-supplicant' returned 100:
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package virtual
```
(notice the `virtual/bootloader` as an argument to `apt-get`)


This fix also enables the user to override the value for `virtual/bootloader` in `IMAGE_INSTALL` by setting `PREFERRED_PROVIDER_virtual/bootloader` in another layer. 

It seems that handling of `IMAGE_INSTALL` is the same between `rpm` and `deb` packaging/installation (i.e. no substitution of the string `virtual/bootloader` in `IMAGE_INSTALL`), however `rpm` (or `dnf`) doesn't seem to have an issue with `virtual/bootloader` as an argument.