### PR TITLE
fw_env.config: Fix device offset

### DIFF
--- a/recipes-bsp/u-boot/files/dh-stm32mp1-dhsom/fw_env.config
+++ b/recipes-bsp/u-boot/files/dh-stm32mp1-dhsom/fw_env.config
@@ -1,3 +1,3 @@
 # MTD device name	Device offset	Env. size	Flash sector size	Number of sectors
-/dev/mtd0		0x1e0000	0x4000		0x1000			1
-/dev/mtd0		0x1f0000	0x4000		0x1000			1
+/dev/mtd0		0x3e0000	0x4000		0x1000			1
+/dev/mtd0		0x3f0000	0x4000		0x1000			1


### PR DESCRIPTION
As of the moment the U-Boot configuration sets `CONFIG_ENV_OFFSET=0x3E0000` and `CONFIG_ENV_OFFSET_REDUND=0x3F0000` but `fw_env.config` uses instead `0x1e0000` and `0x1f0000`. As a result there are run-time issues:
https://github.com/dh-electronics/meta-dhsom-stm32-bsp/blob/scarthgap/recipes-bsp/u-boot/files/0021-ARM-dts-stm32-Add-support-for-STM32MP13xx-DHCOR-SoM-.patch#L864C2-L864C19

This patch fixes device offset in `fw_env.config` to match the values of `CONFIG_ENV_OFFSET` and `CONFIG_ENV_OFFSET_REDUND` from U-Boot's `stm32mp13_dhcor_defconfig`.